### PR TITLE
Add "rename_from_file"

### DIFF
--- a/out/api.go
+++ b/out/api.go
@@ -10,11 +10,12 @@ type Request struct {
 }
 
 type Params struct {
-	Metalink string                 `json:"metalink"`
-	Files    []string               `json:"files"`
-	Version  string                 `json:"version"`
-	Rename   string                 `json:"rename,omitempty"`
-	Options  map[string]interface{} `json:"options,omitempty"`
+	Metalink       string                 `json:"metalink"`
+	Files          []string               `json:"files"`
+	Version        string                 `json:"version"`
+	Rename         string                 `json:"rename,omitempty"`
+	RenameFromFile string                 `json:"rename_from_file,omitempty"`
+	Options        map[string]interface{} `json:"options,omitempty"`
 }
 
 type Response struct {

--- a/out/main.go
+++ b/out/main.go
@@ -87,6 +87,13 @@ func main() {
 
 	if request.Params.Rename != "" {
 		metalinkName = request.Params.Rename
+	} else if request.Params.RenameFromFile != "" {
+		var metalinkNameBytes []byte
+		metalinkNameBytes, err = ioutil.ReadFile(metalinkPath)
+		if err != nil {
+			api.Fatal("out: could not open rename file: read error", err)
+		}
+		metalinkName = string(metalinkNameBytes)
 	} else {
 		metalinkName = fmt.Sprintf("v%s.meta4", meta4.Files[0].Version)
 	}


### PR DESCRIPTION
This allows the metalink filename to be passed in via an input resource,
which enables the metalink filename to be dynamically generated.

Co-authored-by: Josh Russett <jrussett@pivotal.io>