### PR TITLE
Add in.Params.IncludeFiles

### DIFF
--- a/in/api.go
+++ b/in/api.go
@@ -31,7 +31,8 @@ func (r Request) ApplyFilter(filter *and.Filter) error {
 }
 
 type Params struct {
-	SkipDownload bool `json:"skip_download"`
+	SkipDownload bool     `json:"skip_download"`
+	IncludeFiles []string `json:"include_files,omitempty"`
 }
 
 type Response struct {

--- a/in/main.go
+++ b/in/main.go
@@ -88,6 +88,19 @@ func main() {
 			}
 		}
 
+		// completely overrides the above block when params.IncludeFiles is present
+		if len(request.Params.IncludeFiles) > 0 {
+			matched = false
+
+			for _, pattern := range request.Params.IncludeFiles {
+				if match, _ := filepath.Match(pattern, file.Name); match {
+					matched = true
+
+					break
+				}
+			}
+		}
+
 		if len(request.Source.ExcludeFiles) > 0 {
 			for _, pattern := range request.Source.ExcludeFiles {
 				if match, _ := filepath.Match(pattern, file.Name); match {


### PR DESCRIPTION
This allows filtering files to download as part of defining the `get`
step. This can be useful when dealing with repositories that provide
several files within the same resource.

Co-authored-by: Aakash Shah <ashah@pivotal.io>
Co-authored-by: Joshua Aresty <joshua.aresty@emc.com>