### PR TITLE
Add filepath filter to Source

### DIFF
--- a/api/filepathfilter.go
+++ b/api/filepathfilter.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"path"
+	"path/filepath"
+
+	"github.com/dpb587/metalink/repository"
+	"github.com/dpb587/metalink/repository/filter"
+)
+
+type FilePathFilter struct {
+	Glob string
+}
+
+var _ filter.Filter = FilePathFilter{}
+
+func CreateFilePathFilter(glob string) (FilePathFilter, error) {
+	_, err := filepath.Match(glob, "")
+	if err != nil {
+		return FilePathFilter{}, err
+	}
+
+	return FilePathFilter{
+		Glob: glob,
+	}, nil
+}
+
+func (f FilePathFilter) IsTrue(meta4 repository.RepositoryMetalink) (bool, error) {
+	match, err := filepath.Match(f.Glob, path.Base(meta4.Reference.Path))
+	if err != nil {
+		return false, err
+	}
+
+	return match, nil
+}

--- a/api/source.go
+++ b/api/source.go
@@ -6,8 +6,9 @@ import (
 )
 
 type Source struct {
-	URI     string                 `json:"uri"`
-	Options map[string]interface{} `json:"options,omitempty"`
+	URI          string                 `json:"uri"`
+	Options      map[string]interface{} `json:"options,omitempty"`
+	MetalinkGlob string                 `json:"metalink_glob,omitempty"`
 
 	SkipHashVerification      bool   `json:"skip_hash_verification,omitempty"`
 	SkipSignatureVerification bool   `json:"skip_signature_verification,omitempty"`

--- a/check/api.go
+++ b/check/api.go
@@ -31,6 +31,15 @@ func (r Request) ApplyFilter(filter *and.Filter) error {
 		filter.Add(addFilter)
 	}
 
+	if r.Source.MetalinkGlob != "" {
+		addFilter, err := api.CreateFilePathFilter(r.Source.MetalinkGlob)
+		if err != nil {
+			return err
+		}
+
+		filter.Add(addFilter)
+	}
+
 	return nil
 }
 

--- a/in/api.go
+++ b/in/api.go
@@ -27,6 +27,15 @@ func (r Request) ApplyFilter(filter *and.Filter) error {
 		filter.Add(addFilter)
 	}
 
+	if r.Source.MetalinkGlob != "" {
+		addFilter, err := api.CreateFilePathFilter(r.Source.MetalinkGlob)
+		if err != nil {
+			return err
+		}
+
+		filter.Add(addFilter)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This allows us to filter metalink files in repositories that have multiple .meta4s in the same directory

Co-authored-by: Joshua Aresty <joshua.aresty@emc.com>